### PR TITLE
Add Google Analytics configuration to deployment workflow and layout

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Build
         run: npm run build
+        env:
+          PUBLIC_GA_MEASUREMENT_ID: ${{ vars.PUBLIC_GA_MEASUREMENT_ID }}
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/README.md
+++ b/README.md
@@ -34,3 +34,9 @@ Output is in `dist/`.
 5. **Base path:** For a user/org site (`username.github.io`), keep `base: '/'` in `astro.config.mjs`. For a project site (`username.github.io/repo-name`), set `site` and `base` in `astro.config.mjs`:
    - `site: 'https://brunodonadio.github.io'`
    - `base: '/repo-name'`
+
+## Google Analytics
+
+- **Local env:** Optionally set `PUBLIC_GA_MEASUREMENT_ID` in a local `.env` file (see `.env.example`).  
+- **Production-only:** Analytics only runs when `import.meta.env.PROD` is `true` and `PUBLIC_GA_MEASUREMENT_ID` is defined, so dev builds do not load GA.  
+- **GitHub Pages:** Configure a repository Actions variable named `PUBLIC_GA_MEASUREMENT_ID` so the deploy workflow can pass it into the Astro build.

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -11,6 +11,7 @@ const { title, description = 'Senior Backend Engineer — platform-minded system
 
 const canonicalURL = new URL(Astro.url.pathname, Astro.site ?? 'https://brunodonadio.github.io');
 const linkedInUrl = 'https://linkedin.com/in/bruno-donadio';
+const GA_MEASUREMENT_ID = import.meta.env.PUBLIC_GA_MEASUREMENT_ID;
 ---
 <!doctype html>
 <html lang="en">
@@ -28,22 +29,31 @@ const linkedInUrl = 'https://linkedin.com/in/bruno-donadio';
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-    <!-- Google tag (gtag.js) -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=G-1CQSKVBM6G"></script>
-    <script>
-      window.dataLayer = window.dataLayer || [];
-      function gtag(){dataLayer.push(arguments);}
-      gtag('js', new Date());
-
-      gtag('config', 'G-1CQSKVBM6G');
-    </script>
-    <script>
-      window.trackGaEvent = function (name, label) {
-        if (typeof window.gtag === 'function') {
-          window.gtag('event', name, { event_category: 'engagement', event_label: label });
-        }
-      };
-    </script>
+    {import.meta.env.PROD && GA_MEASUREMENT_ID && (
+      <>
+        <script
+          async
+          src={`https://www.googletagmanager.com/gtag/js?id=${GA_MEASUREMENT_ID}`}
+        ></script>
+        <script>
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){window.dataLayer.push(arguments);}
+          window.gtag = gtag;
+          gtag('js', new Date());
+          gtag('config', import.meta.env.PUBLIC_GA_MEASUREMENT_ID);
+        </script>
+        <script>
+          window.trackGaEvent = function (name, label) {
+            if (typeof window.gtag === 'function') {
+              window.gtag('event', name, {
+                event_category: 'engagement',
+                event_label: label
+              });
+            }
+          };
+        </script>
+      </>
+    )}
   </head>
   <body class="min-h-screen font-sans">
     <header


### PR DESCRIPTION
- Updated deploy.yml to pass PUBLIC_GA_MEASUREMENT_ID as an environment variable during the build process.
- Enhanced Layout.astro to conditionally load Google Analytics scripts based on the presence of PUBLIC_GA_MEASUREMENT_ID and production environment.
- Added Google Analytics setup instructions to README.md for local and production environments.